### PR TITLE
list board files in alphabetical order

### DIFF
--- a/micropython.js
+++ b/micropython.js
@@ -233,6 +233,9 @@ class MicroPythonBoard {
     let files = output[2] || ''
     files = files.slice(0, files.indexOf(']')+1)
     files = JSON.parse(files)
+    files.sort(function (a, b) {
+      return a.localeCompare(b);
+    });
     return Promise.resolve(files)
   }
 


### PR DESCRIPTION
Previously the files would be listed based on their name's characters position in the character table, hence capitalised file names would all be listed first. This PR sorts the `files` array using a sort function based on `localeCompare()`