### PR TITLE
Bugfix/run twice

### DIFF
--- a/micropython.js
+++ b/micropython.js
@@ -164,6 +164,7 @@ class MicroPythonBoard {
         return resolve(output)
       } catch (e) {
         reject(e)
+        this.reject_run = null
       }
     })
   }

--- a/micropython.js
+++ b/micropython.js
@@ -28,6 +28,7 @@ class MicroPythonBoard {
   constructor() {
     this.port = null
     this.serial = null
+    this.reject_run = null
   }
 
   list_ports() {
@@ -113,7 +114,10 @@ class MicroPythonBoard {
   }
 
   async get_prompt() {
-    const out = await this.write_and_read_until(`\r\x02\x03`, '\r\n>>>')
+    await sleep(100)
+    await this.stop()
+    await sleep(100)
+    const out = await this.write_and_read_until(`\r\x03\x02`, '\r\n>>>')
     return Promise.resolve(out)
   }
 
@@ -147,10 +151,21 @@ class MicroPythonBoard {
 
   async run(code, data_consumer) {
     data_consumer = data_consumer || function() {}
-    await this.enter_raw_repl()
-    const output = await this.exec_raw(code || '#', data_consumer)
-    await this.exit_raw_repl()
-    return Promise.resolve(output)
+    return new Promise(async (resolve, reject) => {
+      if (this.reject_run) {
+        this.reject_run('re run')
+        this.reject_run = null
+      }
+      this.reject_run = reject
+      try {
+        await this.enter_raw_repl()
+        const output = await this.exec_raw(code || '#', data_consumer)
+        await this.exit_raw_repl()
+        return resolve(output)
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 
   async eval(k) {
@@ -159,12 +174,20 @@ class MicroPythonBoard {
   }
 
   async stop() {
+    if (this.reject_run) {
+      this.reject_run('pre stop')
+      this.reject_run = null
+    }
     // Dismiss any data with ctrl-C
     await this.serial.write(Buffer.from(`\x03`))
     return Promise.resolve()
   }
 
   async reset() {
+    if (this.reject_run) {
+      this.reject_run('pre reset')
+      this.reject_run = null
+    }
     // Dismiss any data with ctrl-C
     await this.serial.write(Buffer.from(`\x03`))
     // Soft reboot

--- a/micropython.js
+++ b/micropython.js
@@ -153,7 +153,7 @@ class MicroPythonBoard {
     data_consumer = data_consumer || function() {}
     return new Promise(async (resolve, reject) => {
       if (this.reject_run) {
-        this.reject_run('re run')
+        this.reject_run(new Error('re-run'))
         this.reject_run = null
       }
       this.reject_run = reject
@@ -176,7 +176,7 @@ class MicroPythonBoard {
 
   async stop() {
     if (this.reject_run) {
-      this.reject_run('pre stop')
+      this.reject_run(new Error('pre stop'))
       this.reject_run = null
     }
     // Dismiss any data with ctrl-C
@@ -186,7 +186,7 @@ class MicroPythonBoard {
 
   async reset() {
     if (this.reject_run) {
-      this.reject_run('pre reset')
+      this.reject_run(new Error('pre reset'))
       this.reject_run = null
     }
     // Dismiss any data with ctrl-C

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micropython.js",
-  "version": "1.3.5",
+  "version": "1.4.1",
   "description": "Interpretation of pyboard.py in javascript",
   "main": "micropython.js",
   "scripts": {


### PR DESCRIPTION
**Problem:**

If you press the button run twice a few breaking situation happen:
- Interrupt first execution but won't run the second time
- Sometimes get stuck on raw repl
- Sometimes run button stops working

This will also make other functions to break (save, list files, etc...)
When entering raw repl again it executes some code automatically a couple of times.
When entering raw repl, typing 'print(123)' and hitting control+D will execute and leave raw repl. It should not leave raw repl.

**Solution:**

Board was getting stuck because promises weren't being "canceled".
Following cue from `micropython-ctl` implementation: The function to reject the `run` promise is stored locally on board class and called before attempting other operations (stop and reset).

**Future improvement:**

Renaming methods because right now it's confusing what's keyboard interrupt and what is stopping a program or getting a prompt. Confusing.
