### PR TITLE
Tentative: Implemented binary output from fs_cat.

### DIFF
--- a/micropython.js
+++ b/micropython.js
@@ -256,7 +256,7 @@ class MicroPythonBoard {
     return Promise.resolve(files)
   }
 
-  async fs_cat(filePath) {
+  async fs_cat_binary(filePath) {
     if (filePath) {
       await this.enter_raw_repl()
       let output = await this.exec_raw(
@@ -269,18 +269,18 @@ class MicroPythonBoard {
     return Promise.reject(new Error(`Path to file was not specified`))
   }
 
-  // async fs_cat(filePath) {
-  //   if (filePath) {
-  //     await this.enter_raw_repl()
-  //     let output = await this.exec_raw(
-  //       `with open('${filePath}','r') as f:\n while 1:\n  b=f.read(256)\n  if not b:break\n  print(b,end='')`
-  //     )
-  //     await this.exit_raw_repl()
-  //     output = extract(output)
-  //     return Promise.resolve(fixLineBreak(output))
-  //   }
-  //   return Promise.reject(new Error(`Path to file was not specified`))
-  // }
+  async fs_cat(filePath) {
+    if (filePath) {
+      await this.enter_raw_repl()
+      let output = await this.exec_raw(
+        `with open('${filePath}','r') as f:\n while 1:\n  b=f.read(256)\n  if not b:break\n  print(b,end='')`
+      )
+      await this.exit_raw_repl()
+      output = extract(output)
+      return Promise.resolve(fixLineBreak(output))
+    }
+    return Promise.reject(new Error(`Path to file was not specified`))
+  }
 
   async fs_put(src, dest, data_consumer) {
     data_consumer = data_consumer || function() {}


### PR DESCRIPTION
This PR is mostly a way to open a discussion about transferring files as binary from the board to the disk (and to a consumer such as Lab for MicroPython Editor.

I have initially implemented a `fs_cat_bytes` method, but it does not belong to the `pyboard.py` API.
Of course the changes to `fs_cat` now won't return text but an Array of numbers.

[This PR](https://github.com/arduino/lab-micropython-editor/pull/140) requires these changes to work, and they are both draft.

To make MicroPython.js consumer agnostic maybe it would make sense to have a way to `fs_cat` bytes and string as separate.

Let's see how we can allow the editor/consumers to download binary files without corrupting them and still make MicroPython.js a clean module 