### PR TITLE
Updated cli.js getFile method to leverage binary transfer.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -140,7 +140,8 @@ const getFile = (args, port, dataConsumer) => {
   return board.open(port)
   .then(async () => {
     try {
-      let output = await board.fs_cat(boardFilename, consumer)
+      let output = await board.fs_cat_binary(boardFilename, consumer)
+      output = Buffer.from(output);
       fs.writeFileSync(diskFilename, output)
       log('output')
       log(output)


### PR DESCRIPTION
The `--getFile` method in `cli.js` was still using the previous implementation of `fs_cat` rather than `fs_cat_binary`.
This PR fixes that and allows for binary transfers from the board.

I am not sure if we can later merge this fix in 1.5.0 rather than creating 1.5.1 since `cli.js` is more of a help/wrap tool to `micropython.js`.

TBD