### PR TITLE
Harden and speed up file downloads (fs_cat_binary)

### DIFF
--- a/micropython.js
+++ b/micropython.js
@@ -58,6 +58,9 @@ class MicroPythonBoard {
     this._hasUbinascii = null
     this._fsRoot = null
     this.chunkSize = 256
+    // How many bytes the board reads per iteration when sending a file back.
+    // Bigger chunks mean fewer iterations, at the cost of board side memory.
+    this.readChunkSize = 768
     this.writeDelay = 10
     this.execTimeout = null
     this._pendingReads = new Set()
@@ -481,14 +484,14 @@ it is currently still available as a transition in consumers such as Arduino Lab
       if (this._hasUbinascii) {
         command =  `with open('${filePath}','rb') as f:\n`
         command += `  while 1:\n`
-        command += `    b=f.read(256)\n`
+        command += `    b=f.read(${this.readChunkSize})\n`
         command += `    if not b:break\n`
         command += `    print(ubinascii.b2a_base64(b).decode(),end='')\n`
         command += `del b\n`
       } else {
         command =  `with open('${filePath}','rb') as f:\n`
         command += `  while 1:\n`
-        command += `    b=f.read(256)\n`
+        command += `    b=f.read(${this.readChunkSize})\n`
         command += `    if not b:break\n`
         command += `    print(b.hex(),end='')\n`
         command += `del b\n`

--- a/micropython.js
+++ b/micropython.js
@@ -549,6 +549,14 @@ it is currently still available as a transition in consumers such as Arduino Lab
       } else {
         result = Buffer.from(output.trim(), 'hex')
       }
+      // Decoding stops at the first character that isn't part of the encoding,
+      // so anything that cut the transfer short would look like a shorter file
+      if (result.length !== fileSize) {
+        throw new MicroPythonError(
+          `Expected ${fileSize} bytes from "${filePath}" but read ${result.length}`,
+          MicroPythonError.UNEXPECTED_RESPONSE, filePath
+        )
+      }
       return Promise.resolve(result)
     }
     return Promise.reject(new MicroPythonError(`Path to file was not specified`, MicroPythonError.MISSING_ARGUMENT))

--- a/micropython.js
+++ b/micropython.js
@@ -497,11 +497,14 @@ it is currently still available as a transition in consumers such as Arduino Lab
       let streamConsumer = null
       if (fileSize > 0) {
         let bytesReceived = 0
+        let hexReceived = 0
         let lineBuf = ''
         let prefixSkipped = false
+        let done = false
         const hasUbinascii = this._hasUbinascii
 
         streamConsumer = (chunk) => {
+          if (done) return
           if (!prefixSkipped) {
             lineBuf += chunk
             const okIdx = lineBuf.indexOf('OK')
@@ -512,7 +515,10 @@ it is currently still available as a transition in consumers such as Arduino Lab
             lineBuf += chunk
           }
           const eotIdx = lineBuf.indexOf('\x04')
-          if (eotIdx !== -1) lineBuf = lineBuf.slice(0, eotIdx)
+          if (eotIdx !== -1) {
+            lineBuf = lineBuf.slice(0, eotIdx)
+            done = true
+          }
 
           if (hasUbinascii) {
             let nlIdx
@@ -525,8 +531,12 @@ it is currently still available as a transition in consumers such as Arduino Lab
               }
             }
           } else {
-            const hexLen = lineBuf.replace(/[^0-9a-fA-F]/g, '').length
-            bytesReceived = Math.floor(hexLen / 2)
+            // Hex has no line breaks to drain on, so count what just arrived
+            // and drop it. Rescanning everything received so far on every
+            // chunk makes the cost grow with the square of the file size.
+            hexReceived += lineBuf.replace(/[^0-9a-fA-F]/g, '').length
+            lineBuf = ''
+            bytesReceived = Math.floor(hexReceived / 2)
             data_consumer(Math.min(99, Math.round(bytesReceived / fileSize * 100)) + '%')
           }
         }

--- a/micropython.js
+++ b/micropython.js
@@ -463,7 +463,19 @@ it is currently still available as a transition in consumers such as Arduino Lab
       await this._checkUbinascii()
 
       const sizeOut = await this.exec_raw(`import os\nprint(os.stat('${filePath}')[6])\n`)
+      const sizeErr = this.exec_raw_err(sizeOut)
+      if (sizeErr.trim()) {
+        await this.exit_raw_repl()
+        throw new MicroPythonError(sizeErr.trim(), MicroPythonError.BOARD_ERROR, filePath)
+      }
       const fileSize = parseInt(extract(sizeOut).trim())
+      if (isNaN(fileSize)) {
+        await this.exit_raw_repl()
+        throw new MicroPythonError(
+          `fs_cat_binary: unexpected output from board: ${JSON.stringify(sizeOut)}`,
+          MicroPythonError.UNEXPECTED_RESPONSE, filePath
+        )
+      }
 
       let command
       if (this._hasUbinascii) {
@@ -522,7 +534,11 @@ it is currently still available as a transition in consumers such as Arduino Lab
 
       data_consumer('0%')
       let output = await this.exec_raw(command, streamConsumer)
+      const readErr = this.exec_raw_err(output)
       await this.exit_raw_repl()
+      if (readErr.trim()) {
+        throw new MicroPythonError(readErr.trim(), MicroPythonError.BOARD_ERROR, filePath)
+      }
       output = extract(output)
       data_consumer('100%')
       let result

--- a/micropython.js
+++ b/micropython.js
@@ -494,6 +494,16 @@ it is currently still available as a transition in consumers such as Arduino Lab
         command += `del b\n`
       }
 
+      // The same whole percentage is reached by many chunks in a row, and
+      // repeating it only makes callers filter it out again
+      let lastProgress = null
+      const report = (percentage) => {
+        const progress = percentage + '%'
+        if (progress === lastProgress) return
+        lastProgress = progress
+        data_consumer(progress)
+      }
+
       let streamConsumer = null
       if (fileSize > 0) {
         let bytesReceived = 0
@@ -527,7 +537,7 @@ it is currently still available as a transition in consumers such as Arduino Lab
               lineBuf = lineBuf.slice(nlIdx + 1)
               if (line.length > 0) {
                 bytesReceived += Buffer.from(line.trim(), 'base64').length
-                data_consumer(Math.min(99, Math.round(bytesReceived / fileSize * 100)) + '%')
+                report(Math.min(99, Math.round(bytesReceived / fileSize * 100)))
               }
             }
           } else {
@@ -537,12 +547,12 @@ it is currently still available as a transition in consumers such as Arduino Lab
             hexReceived += lineBuf.replace(/[^0-9a-fA-F]/g, '').length
             lineBuf = ''
             bytesReceived = Math.floor(hexReceived / 2)
-            data_consumer(Math.min(99, Math.round(bytesReceived / fileSize * 100)) + '%')
+            report(Math.min(99, Math.round(bytesReceived / fileSize * 100)))
           }
         }
       }
 
-      data_consumer('0%')
+      report(0)
       let output = await this.exec_raw(command, streamConsumer)
       const readErr = this.exec_raw_err(output)
       await this.exit_raw_repl()
@@ -550,7 +560,7 @@ it is currently still available as a transition in consumers such as Arduino Lab
         throw new MicroPythonError(readErr.trim(), MicroPythonError.BOARD_ERROR, filePath)
       }
       output = extract(output)
-      data_consumer('100%')
+      report(100)
       let result
       if (this._hasUbinascii) {
         result = Buffer.concat(


### PR DESCRIPTION
## Changes

**Board errors were swallowed** (`d9d1aba`). `fs_cat_binary` ignored stderr from both the stat and the read, so downloading a file that does not exist resolved with an empty buffer and `fs_get` wrote a 0 byte file to disk. It now checks `exec_raw_err` like the other `fs_` methods and rejects with a typed error, leaving the raw REPL first so the board stays usable.

**Downloads were unverified** (`f62be76`). Base64 and hex decoding both stop at the first character outside the alphabet, so a transfer cut short decodes into a shorter file with no error at all. The stat already performed for the progress bar tells us how many bytes to expect, so the decoded length is now compared against it.

**Progress accounting scaled quadratically** (`7f5be46`). The hex fallback has no line breaks to drain on, so its buffer grew to hold the entire file and was rescanned from the start for every chunk that arrived. Replaying the stream of a 960 KB file cost 10.2 s of scanning alone, against 5 ms once only newly arrived characters are counted.

**Reads were smaller than they need to be** (`b825ccb`). The board read 256 bytes per iteration; 768 takes a 90 KB download from 589 ms to 537 ms for about 1.8 KB of board side memory. This is a new `readChunkSize` setting rather than the existing `chunkSize`, which is how much we *write* to the board at once and is tied to the write delay calibration — pointing downloads at that field would invalidate a calibrated `writeDelay`.

**Every percentage was reported many times** (`fe45d9a`). Many chunks land within the same whole percentage and each one triggered a callback. A 90 KB download called back 939 times on the hex path to say 101 different things; now it is 101 calls, strictly increasing, `0%` to `100%`.

## Testing

Verified against an Arduino Nano ESP32 (MicroPython 1.28.0-preview) throughout:

- Downloads byte exact against a board side `hashlib` SHA-256, on both the base64 and hex paths, at read chunk sizes from 3 to 30000.
- Missing file rejects with `BOARD_ERROR` and no file is written; the board is immediately usable afterwards.
- Truncation caught: trimming 2 KB from the board's response gives `UNEXPECTED_RESPONSE | Expected 30848 bytes ... but read 29371`.
- Empty files, small files and repeated calls in one session all behave; a failed read emits no bogus `100%`.
- Quadratic fix measured by replaying identical streams through the old and new accounting, with matching final byte counts.
- Timings are medians of 5 interleaved runs per variant on the same board.

## Notes for reviewers

- `readChunkSize` is a plain instance field; there is no validation on it beyond what the board itself enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
